### PR TITLE
Changes movementdelay() values to decrease the speed of all xenos except queens and facehuggers

### DIFF
--- a/drone.dm
+++ b/drone.dm
@@ -1,0 +1,49 @@
+/mob/living/carbon/alien/humanoid/drone
+	name = "alien drone"
+	caste = "d"
+	maxHealth = 125
+	health = 125
+	icon_state = "aliend"
+
+
+/mob/living/carbon/alien/humanoid/drone/Initialize()
+	AddAbility(new/obj/effect/proc_holder/alien/evolve(null))
+	. = ..()
+
+
+/mob/living/carbon/alien/humanoid/drone/create_internal_organs()
+	internal_organs += new /obj/item/organ/alien/plasmavessel/large
+	internal_organs += new /obj/item/organ/alien/resinspinner
+	internal_organs += new /obj/item/organ/alien/acid
+	..()
+
+/mob/living/carbon/alien/humanoid/drone/movement_delay()
+	. = ..()
+	. += 1		//xeno movement delay balance
+
+/obj/effect/proc_holder/alien/evolve
+	name = "Evolve to Praetorian"
+	desc = "Praetorian"
+	plasma_cost = 500
+
+	action_icon_state = "alien_evolve_drone"
+
+/obj/effect/proc_holder/alien/evolve/fire(mob/living/carbon/alien/humanoid/user)
+	var/obj/item/organ/alien/hivenode/node = user.getorgan(/obj/item/organ/alien/hivenode)
+	if(!node) //Players are Murphy's Law. We may not expect there to ever be a living xeno with no hivenode, but they _WILL_ make it happen.
+		to_chat(user, "<span class='danger'>Without the hivemind, you can't possibly hold the responsibility of leadership!</span>")
+		return 0
+	if(node.recent_queen_death)
+		to_chat(user, "<span class='danger'>Your thoughts are still too scattered to take up the position of leadership.</span>")
+		return 0
+
+	if(!isturf(user.loc))
+		to_chat(user, "<span class='notice'>You can't evolve here!</span>")
+		return 0
+	if(!get_alien_type(/mob/living/carbon/alien/humanoid/royal))
+		var/mob/living/carbon/alien/humanoid/royal/praetorian/new_xeno = new (user.loc)
+		user.alien_evolve(new_xeno)
+		return 1
+	else
+		to_chat(user, "<span class='notice'>We already have a living royal!</span>")
+		return 0

--- a/hunter.dm
+++ b/hunter.dm
@@ -1,0 +1,103 @@
+/mob/living/carbon/alien/humanoid/hunter
+	name = "alien hunter"
+	caste = "h"
+	maxHealth = 125
+	health = 125
+	icon_state = "alienh"
+	var/obj/screen/leap_icon = null
+
+/mob/living/carbon/alien/humanoid/hunter/create_internal_organs()
+	internal_organs += new /obj/item/organ/alien/plasmavessel/small
+	..()
+
+/mob/living/carbon/alien/humanoid/hunter/movement_delay()
+	//. = -1	//hunters are sanic
+	. += ..()	//but they still need to slow down on stun
+				//hunters are no longer "sanic", but also do not have positive movement delay still
+
+
+//Hunter verbs
+
+/mob/living/carbon/alien/humanoid/hunter/proc/toggle_leap(message = 1)
+	leap_on_click = !leap_on_click
+	leap_icon.icon_state = "leap_[leap_on_click ? "on":"off"]"
+	update_icons()
+	if(message)
+		to_chat(src, "<span class='noticealien'>You will now [leap_on_click ? "leap at":"slash at"] enemies!</span>")
+	else
+		return
+
+
+/mob/living/carbon/alien/humanoid/hunter/ClickOn(atom/A, params)
+	face_atom(A)
+	if(leap_on_click)
+		leap_at(A)
+	else
+		..()
+
+
+#define MAX_ALIEN_LEAP_DIST 7
+
+/mob/living/carbon/alien/humanoid/hunter/proc/leap_at(atom/A)
+	if(!canmove || leaping)
+		return
+
+	if(pounce_cooldown > world.time)
+		to_chat(src, "<span class='alertalien'>You are too fatigued to pounce right now!</span>")
+		return
+
+	if(!has_gravity() || !A.has_gravity())
+		to_chat(src, "<span class='alertalien'>It is unsafe to leap without gravity!</span>")
+		//It's also extremely buggy visually, so it's balance+bugfix
+		return
+
+	else //Maybe uses plasma in the future, although that wouldn't make any sense...
+		leaping = 1
+		weather_immunities += "lava"
+		update_icons()
+		throw_at(A, MAX_ALIEN_LEAP_DIST, 1, src, FALSE, TRUE, callback = CALLBACK(src, .leap_end))
+
+/mob/living/carbon/alien/humanoid/hunter/proc/leap_end()
+	leaping = 0
+	weather_immunities -= "lava"
+	update_icons()
+
+/mob/living/carbon/alien/humanoid/hunter/throw_impact(atom/A)
+
+	if(!leaping)
+		return ..()
+
+	pounce_cooldown = world.time + pounce_cooldown_time
+	if(A)
+		if(isliving(A))
+			var/mob/living/L = A
+			var/blocked = FALSE
+			if(ishuman(A))
+				var/mob/living/carbon/human/H = A
+				if(H.check_shields(src, 0, "the [name]", attack_type = LEAP_ATTACK))
+					blocked = TRUE
+			if(!blocked)
+				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
+				L.Knockdown(100)
+				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
+				step_towards(src,L)
+			else
+				Knockdown(40, 1, 1)
+
+			toggle_leap(0)
+		else if(A.density && !A.CanPass(src))
+			visible_message("<span class ='danger'>[src] smashes into [A]!</span>", "<span class ='alertalien'>[src] smashes into [A]!</span>")
+			Knockdown(40, 1, 1)
+
+		if(leaping)
+			leaping = 0
+			update_icons()
+			update_canmove()
+
+
+/mob/living/carbon/alien/humanoid/float(on)
+	if(leaping)
+		return
+	..()
+
+

--- a/praetorian.dm
+++ b/praetorian.dm
@@ -1,0 +1,52 @@
+/mob/living/carbon/alien/humanoid/royal/praetorian
+	name = "alien praetorian"
+	caste = "p"
+	maxHealth = 250
+	health = 250
+	icon_state = "alienp"
+
+
+
+/mob/living/carbon/alien/humanoid/royal/praetorian/Initialize()
+
+	real_name = name
+
+	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/repulse/xeno(src))
+	AddAbility(new /obj/effect/proc_holder/alien/royal/praetorian/evolve())
+	. = ..()
+
+/mob/living/carbon/alien/humanoid/royal/praetorian/create_internal_organs()
+	internal_organs += new /obj/item/organ/alien/plasmavessel/large
+	internal_organs += new /obj/item/organ/alien/resinspinner
+	internal_organs += new /obj/item/organ/alien/acid
+	internal_organs += new /obj/item/organ/alien/neurotoxin
+	..()
+
+
+/mob/living/carbon/alien/humanoid/royal/praetorian/movement_delay()
+	. = ..()
+	//. += 1	//making praetorian even slower to account for new movement delays
+	. += 2		//xeno movement delay balance
+
+/obj/effect/proc_holder/alien/royal/praetorian/evolve
+	name = "Evolve"
+	desc = "Produce an interal egg sac capable of spawning children. Only one queen can exist at a time."
+	plasma_cost = 500
+
+	action_icon_state = "alien_evolve_praetorian"
+
+/obj/effect/proc_holder/alien/royal/praetorian/evolve/fire(mob/living/carbon/alien/humanoid/user)
+	var/obj/item/organ/alien/hivenode/node = user.getorgan(/obj/item/organ/alien/hivenode)
+	if(!node) //Just in case this particular Praetorian gets violated and kept by the RD as a replacement for Lamarr.
+		to_chat(user, "<span class='danger'>Without the hivemind, you would be unfit to rule as queen!</span>")
+		return 0
+	if(node.recent_queen_death)
+		to_chat(user, "<span class='danger'>You are still too burdened with guilt to evolve into a queen.</span>")
+		return 0
+	if(!get_alien_type(/mob/living/carbon/alien/humanoid/royal/queen))
+		var/mob/living/carbon/alien/humanoid/royal/queen/new_xeno = new (user.loc)
+		user.alien_evolve(new_xeno)
+		return 1
+	else
+		to_chat(user, "<span class='notice'>We already have an alive queen.</span>")
+		return 0

--- a/sentinel.dm
+++ b/sentinel.dm
@@ -1,0 +1,22 @@
+/mob/living/carbon/alien/humanoid/sentinel
+	name = "alien sentinel"
+	caste = "s"
+	maxHealth = 150
+	health = 150
+	icon_state = "aliens"
+
+
+/mob/living/carbon/alien/humanoid/sentinel/Initialize()
+	AddAbility(new /obj/effect/proc_holder/alien/sneak)
+	. = ..()
+
+/mob/living/carbon/alien/humanoid/sentinel/create_internal_organs()
+	internal_organs += new /obj/item/organ/alien/plasmavessel
+	internal_organs += new /obj/item/organ/alien/acid
+	internal_organs += new /obj/item/organ/alien/neurotoxin
+	..()
+
+
+/mob/living/carbon/alien/humanoid/sentinel/movement_delay()
+	. = ..()
+	. += 1		//added to make xeno speed more balanced


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This comments out any old values that modify the speed of player-controlled alien mobs and replaces them with new values that make all xenos slower. Queen and facehugger are untouched, but praetorians now move even slower, hunters are no longer "sanic" fast, and drones and sentinels have +1 added to their movement delay so they move more similarly to humans. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Response to request from Kabra to make xenos a reasonable speed. Not really a problem, but it will make them more balanced so they can be used as antagonists occasionally without zipping around at lightning speed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested a bunch of changes to the speed variable in \code\modules\mob\living\simple_animal\hostile\alien.dm without luck, but testing changes to values like /mob/living/carbon/alien/humanoid/royal/praetorian/movement_delay() and /mob/living/carbon/alien/humanoid/hunter/movement_delay() produced a successfully modified movement speed. 

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
tweak: movement_delay() values adjusted
balance: xeno movement speed rebalanced
/:cl:
